### PR TITLE
HMACSHA 256,384,512 fix

### DIFF
--- a/MachineKey/AspDotNetWrapper/AspDotNetWrapper/Customization/EncryptDecrypt.cs
+++ b/MachineKey/AspDotNetWrapper/AspDotNetWrapper/Customization/EncryptDecrypt.cs
@@ -126,7 +126,8 @@ namespace NotSoSecure.AspDotNetWrapper
                                 }
                             }
                             catch (Exception e)
-                            {
+                            {   
+                                Console.WriteLine("Error Decoding ViewState: " + e);
                             }
                         }
                         if (bFound)

--- a/MachineKey/AspDotNetWrapper/AspDotNetWrapper/Customization/ViewStateHelper.cs
+++ b/MachineKey/AspDotNetWrapper/AspDotNetWrapper/Customization/ViewStateHelper.cs
@@ -11,7 +11,7 @@ namespace NotSoSecure.AspDotNetWrapper
 {
     class ViewStateHelper
     {
-        public static string[] algorithms = { "MD5", "SHA1", "SHA256", "SHA384", "SHA512"};
+        public static string[] algorithms = { "MD5", "SHA1", "HMACSHA256", "HMACSHA384", "HMACSHA512"};
         public static int[] hashSizes = { 16, 20, 32, 48, 64 };
 
         public static string DecodeData(string strValidationKey, string strValidationAlgorithm, byte[] protectedData, string modifier)


### PR DESCRIPTION
HMACSHA 256, 384, and 512 are not working in build release version 3, causing false negatives. Keys were skipped over without actually being checked. 
 Fixed these algo's being skipped over, and added an error message print statement to the ViewStateDecode try catch block.